### PR TITLE
Validate DNS name compression flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,4 +449,17 @@ mod tests {
         };
         assert_eq!(record, expected);
     }
+
+    #[test]
+    fn test_parse_ip_address() {
+        let record = DNSRecord {
+            name: String::new(),
+            type_: 1,
+            class: 1,
+            ttl: 0,
+            data: vec![1, 2, 3, 4],
+        };
+        let ip = record.parse_ip_address().unwrap();
+        assert_eq!(ip, std::net::Ipv4Addr::new(1, 2, 3, 4));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ fn main() {
     }
 
     let domain = args.nth(1).unwrap();
-    let ip = resolve_domain(domain);
-    println!("IP address: {}", ip);
+    match resolve_domain(domain) {
+        Ok(ip) => println!("IP address: {}", ip),
+        Err(e) => eprintln!("Error: {}", e),
+    }
 }


### PR DESCRIPTION
## Summary
- reject DNS labels with unsupported high-bit patterns
- return a dedicated `DnsError` instead of panicking or using string errors
- propagate errors across domain resolution and record parsing
- surface DNS question parse failures as `DnsError`

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6898f83d7d288328bdd29fd2b225dcca